### PR TITLE
Added provisory vim navigation

### DIFF
--- a/bible/listwin.py
+++ b/bible/listwin.py
@@ -38,6 +38,21 @@ class ListWindow:
         self.update_bounds()
         self.draw()
 
+    def select_last(self):
+        new_index = len(self._item_tuples) - 1
+
+        self._selected_tuple = self._item_tuples[new_index]
+        self.update_bounds()
+        self.draw()
+
+    def select_first(self):
+        new_index = 0 
+
+        self._selected_tuple = self._item_tuples[new_index]
+        self.update_bounds()
+        self.draw()
+
+
     def update_bounds(self):
         index = self._selected_tuple[0]
         (bound_lower, bound_upper) = self._bounds

--- a/bible/main.py
+++ b/bible/main.py
@@ -166,6 +166,32 @@ class Main:
                 self.selected_window = self.windows_tuples[new_windex]
                 self.selected_window[1].set_active(True)
 
+            if key == ord('k'):
+                self.selected_window[1].increment_selection(-1)
+
+            elif key == ord('j'):
+                self.selected_window[1].increment_selection(1)
+
+            elif key == ord('h'):
+                self.deactivate_all_windows()
+
+                new_windex = self.selected_window[0] - 1
+                if new_windex < 0:
+                    new_windex = len(self.windows_tuples) - 1
+
+                self.selected_window = self.windows_tuples[new_windex]
+                self.selected_window[1].set_active(True)
+
+            elif key == ord('l'):
+                self.deactivate_all_windows()
+
+                new_windex = self.selected_window[0] + 1
+                if new_windex >= len(self.windows_tuples):
+                    new_windex = 0
+
+                self.selected_window = self.windows_tuples[new_windex]
+                self.selected_window[1].set_active(True)
+
             self.update_selections()
             self.update_text()
 

--- a/bible/main.py
+++ b/bible/main.py
@@ -5,9 +5,9 @@ import curses
 from textwrap2 import wrap
 from hyphen import Hyphenator
 
-from .reader import Reader
-from .textwin import TextWindow
-from .listwin import ListWindow
+from reader import Reader
+from textwin import TextWindow
+from listwin import ListWindow
 
 TRANSLATIONS_WIDTH = 6
 BOOKS_WIDTH = 14
@@ -166,7 +166,13 @@ class Main:
                 self.selected_window = self.windows_tuples[new_windex]
                 self.selected_window[1].set_active(True)
 
-            if key == ord('k'):
+            elif key == ord('G'):
+                self.selected_window[1].select_last()
+
+            elif key == ord('g'):
+                self.selected_window[1].select_first()
+
+            elif key == ord('k'):
                 self.selected_window[1].increment_selection(-1)
 
             elif key == ord('j'):


### PR DESCRIPTION
This is a very provisory non-modal implementation of hjkl vim keybindings. 

I guess first some implementation of modality (like in vim) should be made. 

This commit will conflict with an implementation of a fuzzy-finder in selection windows, that is on the todo list of the project.